### PR TITLE
Support NO_CONFIG_OVERRIDE to skip copying config dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,7 @@ before_install:
 ```
 
 If you wish to use the lighter *testmodel*, replace `init-biotestmine.sh` with `init-testmine.sh`.
+
+## Full processing of biotestmine dataset
+
+The `init-biotestmine.sh` script uses a stripped down `project.xml` for processing the dataset. If you miss any features, you can specify `NO_CONFIG_OVERRIDE=true` when invoking the script to use the complete (albeit heavier) `project.xml` in the [biotestmine repository](https://github.com/intermine/biotestmine/blob/master/data/project.xml).

--- a/init-biotestmine.sh
+++ b/init-biotestmine.sh
@@ -16,6 +16,10 @@ else
     GET='wget -O -'
 fi
 
+if test -z $NO_CONFIG_OVERRIDE; then
+  NO_CONFIG_OVERRIDE=false
+fi
+
 cd $HOME
 
 # Pull in the server code.
@@ -42,7 +46,9 @@ echo '#---> Setting up perl dependencies'
 $SCRIPT_DIR/init-perl.sh
 
 # Copy CI-specific config
-cp $CONFIG_DIR/* biotestmine/
+if ! $NO_CONFIG_OVERRIDE; then
+  cp $CONFIG_DIR/* biotestmine/
+fi
 
 # We will need a fully operational web-application
 echo '#---> Building and releasing web application to test against'


### PR DESCRIPTION
@danielabutano's malaria-light dataset works great! Although I think it's a good idea to keep the slimmed down `project.xml` as well, until we find we need the full processing for testing. So I'll add an envvar for activating this instead.