### PR TITLE
Temporary workaround for 404 on first tomcatStartWar

### DIFF
--- a/init-biotestmine.sh
+++ b/init-biotestmine.sh
@@ -67,10 +67,14 @@ fi
 # We will need a fully operational web-application
 if $BUILD_DATASET; then
   echo '#---> Building and releasing web application to test against'
-  (cd biotestmine && ./setup.sh) &
+  cd biotestmine
+  ./setup.sh &
   # Gradle doesn't actually finish executing, so we daemonize it, wait and pray
   # that it finishes in time.
   sleep 600
+  ./gradlew --stop
+  ./gradlew tomcatStartWar &
+  sleep 60
 else
   echo '#---> Restoring and releasing web application to test against'
   echo '#---> Checking databases...'
@@ -91,6 +95,9 @@ else
   cd biotestmine
   ./gradlew postprocess -Pprocess=create-autocomplete-index
   ./gradlew postprocess -Pprocess=create-search-index
+  ./gradlew tomcatStartWar &
+  sleep 60
+  ./gradlew --stop
   ./gradlew tomcatStartWar &
   sleep 60
 fi

--- a/init-testmine.sh
+++ b/init-testmine.sh
@@ -35,8 +35,12 @@ $SCRIPT_DIR/init-solr.sh
 
 # We will need a fully operational web-application
 echo '#---> Building and releasing web application to test against'
-(cd testmodel/testmine && ./setup.sh)
+cd testmodel/testmine
+./setup.sh &
 sleep 60 # let webapp startup
+./gradlew --stop
+./gradlew tomcatStartWar &
+sleep 60
 
 # Warm up the keyword search by requesting results, but ignoring the results
 $GET "http://localhost:8080/intermine-demo/service/search" > /dev/null

--- a/init-testmine.sh
+++ b/init-testmine.sh
@@ -36,11 +36,9 @@ $SCRIPT_DIR/init-solr.sh
 # We will need a fully operational web-application
 echo '#---> Building and releasing web application to test against'
 cd testmodel/testmine
-./setup.sh &
+./setup.sh
+
 sleep 60 # let webapp startup
-./gradlew --stop
-./gradlew tomcatStartWar &
-sleep 60
 
 # Warm up the keyword search by requesting results, but ignoring the results
 $GET "http://localhost:8080/intermine-demo/service/search" > /dev/null


### PR DESCRIPTION
This bug seems to have been introduced when the gradle version was
upgraded from 4.1 to 4.9.

This PR checks to see if this simple workaround fixes CI.